### PR TITLE
Update scripts for vtr-symbiflow

### DIFF
--- a/run-vtr-symbiflow.sh
+++ b/run-vtr-symbiflow.sh
@@ -23,6 +23,7 @@ ls -l
 )
 
 export VPR=$(realpath $PWD/$VTR_DIR/vpr/vpr)
+export GENFASM=$(realpath $PWD/$VTR_DIR/build/utils/fasm/genfasm)
 $VPR --version
 
 # Run the reg test.
@@ -32,5 +33,6 @@ $VPR --version
 	# Build SymbiFlow Arch Defs environment
 	source $SCRIPT_DIR/steps/arch-defs-build.sh
 	# Run the SymbiFlow Arch Defs test
+	cd build
 	source $SCRIPT_DIR/steps/arch-defs-test.sh
 )

--- a/steps/arch-defs-build.sh
+++ b/steps/arch-defs-build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+export CMAKE_FLAGS=-GNinja
 make env

--- a/steps/arch-defs-test.sh
+++ b/steps/arch-defs-test.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-if [ z$ARCH_DEFS_TEST == z ]; then
-	export ARCH_DEFS_TEST=all_demos
-fi
-make $ARCH_DEFS_TEST
+export ARCH_DEFS_TEST=${ARCH_DEFS_TEST:-all_demos}
+export VPR_NUM_WORKERS=${CORES}
+export NUM_JOBS=${NUM_CORES:-${MAX_CORES}}
+
+echo "ARCH_DEFS_TEST=${ARCH_DEFS_TEST}"
+echo "VPR_NUM_WORKERS=${VPR_NUM_WORKERS}"
+echo "NUM_JOBS=${NUM_JOBS}"
+
+ninja all_conda
+ninja -j${NUM_JOBS} ${ARCH_DEFS_TEST}


### PR DESCRIPTION
- Add GENFASM env var to point to the build version
- Use ninja over Make
- Limit number of cores to NUM_CORES, which defaults to nproc for now