### PR TITLE
Disable running of V2X tests

### DIFF
--- a/steps/arch-defs-test.sh
+++ b/steps/arch-defs-test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 export ARCH_DEFS_TEST=${ARCH_DEFS_TEST:-all_demos}
-export V2X_TEST=${V2X_TEST:-all_v2x_tests}
 export VPR_NUM_WORKERS=${CORES}
 export NUM_JOBS=${MAX_CORES}
 
@@ -26,12 +25,6 @@ echo "========================================"
 echo "Running tests"
 echo "----------------------------------------"
 ninja -j${NUM_JOBS} ${ARCH_DEFS_TEST}
-
-echo ""
-echo "========================================"
-echo "Running v2x tests"
-echo "----------------------------------------"
-ninja -j${NUM_JOBS} ${V2X_TEST}
 
 echo ""
 echo "========================================"


### PR DESCRIPTION
Signed-off-by: Maciej Kurc <mkurc@antmicro.com>

Since V2X is now in a separate repo (along with its tests) the PR https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1397 makes it a submodule and removes its tests from the arch-defs repo. The V2X tests are not there and should not be run by kokoro anymore.