### PR TITLE
Use capnp files from VTR folder, rather than from VTR conda package.

### DIFF
--- a/run-vtr-symbiflow.sh
+++ b/run-vtr-symbiflow.sh
@@ -22,6 +22,7 @@ ls -l
 	ls -l
 )
 
+export VTR_ROOT=$(realpath $PWD/$VTR_DIR)
 export VPR=$(realpath $PWD/$VTR_DIR/vpr/vpr)
 export GENFASM=$(realpath $PWD/$VTR_DIR/build/utils/fasm/genfasm)
 $VPR --version

--- a/steps/arch-defs-build.sh
+++ b/steps/arch-defs-build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export CMAKE_FLAGS=-GNinja
+export CMAKE_FLAGS="-GNinja -DVPR_CAPNP_SCHEMA_DIR=$VTR_ROOT/libs/libvtrcapnproto/gen/"
 make env


### PR DESCRIPTION
This enables testing of capnp changes that are not backwards capatible
with the capnp files from the VTR conda package.

Ideally no backwards incompatibile would be made, however examples like
https://github.com/SymbiFlow/vtr-verilog-to-routing/pull/525 which are
trying to be backwards compatibile with upstream VTR, require breaking
compatibility with current downstream Symbiflow VTR.