### PR TITLE
Update symbiflow-arch-def CI script to use make-env

### DIFF
--- a/run-vtr-symbiflow.sh
+++ b/run-vtr-symbiflow.sh
@@ -33,6 +33,8 @@ $VPR --version
 	source $SCRIPT_DIR/steps/git.sh
 	# Build SymbiFlow Arch Defs environment
 	source $SCRIPT_DIR/steps/arch-defs-build.sh
+	# Enter the conda environment
+	source env/conda/bin/activate symbiflow_arch_def_base
 	# Run the SymbiFlow Arch Defs test
 	cd build
 	source $SCRIPT_DIR/steps/arch-defs-test.sh

--- a/steps/arch-defs-test.sh
+++ b/steps/arch-defs-test.sh
@@ -11,14 +11,8 @@ echo ""
 echo "ARCH_DEFS_TEST=${ARCH_DEFS_TEST}"
 echo "VPR_NUM_WORKERS=${VPR_NUM_WORKERS}"
 echo "NUM_JOBS=${NUM_JOBS}"
-
-echo ""
-echo "========================================"
-echo "Preparing to build conda environment"
-echo "----------------------------------------"
 date
 echo ""
-ninja all_conda
 
 echo ""
 echo "========================================"


### PR DESCRIPTION
The PR contains adjustments needed for using the make-env conda environment management tool by the `run-vtr-symbiflow.sh` script.
