### PR TITLE
vtr: install python requirements after the vtr build

### DIFF
--- a/steps/hostsetup.sh
+++ b/steps/hostsetup.sh
@@ -69,18 +69,6 @@ sudo apt-get install -y \
         libtbb-dev \
         virtualenv \
 
-echo "----------------------------------------"
-echo
-echo "========================================"
-echo "Host install python packages"
-echo "----------------------------------------"
-pyenv install -f 3.6.3
-pyenv global 3.6.3
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-python3 get-pip.py
-rm get-pip.py
-python3 -m pip install -r requirements.txt
-
 if [ -z "${BUILD_TOOL}" ]; then
     export BUILD_TOOL=make
 fi

--- a/steps/vtr-build.sh
+++ b/steps/vtr-build.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+echo "========================================"
+echo "Install python requirements"
+echo "----------------------------------------"
+pyenv install -f 3.6.3
+pyenv global 3.6.3
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3 get-pip.py
+rm get-pip.py
+python3 -m pip install -r requirements.txt
+
+echo "----------------------------------------"
+echo
+echo "========================================"
+echo "Build VTR"
+echo "----------------------------------------"
 export FAILURE=0
 make -k CMAKE_PARAMS="-DVTR_ASSERT_LEVEL=3" -j$MAX_CORES || export FAILURE=1
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

CI fails as it cannot find the requirements. This is due to the fact that the requirements are in the vtr repository. This PR moves the python dependencies installation during the VTR build